### PR TITLE
Use math.min in favour of ternary

### DIFF
--- a/src/commands/next.js
+++ b/src/commands/next.js
@@ -5,7 +5,7 @@ module.exports = class NextCommand extends LinkedCommand {
   constructor (main) {
     super(main, {
       description: 'Plays the next song.',
-      triggers: [ 'next', 'skip' ],
+      triggers: [ 'next', 'skip', 'kip' ],
       order: 6
     });
   }

--- a/src/commands/seek.js
+++ b/src/commands/seek.js
@@ -40,9 +40,7 @@ module.exports = class SeekCommand extends LinkedCommand {
     }
 
     await spotifyOAuth.seek(link, position);
-    const realPosition = position > player.item.duration_ms
-      ? player.item.duration_ms
-      : position;
+    const realPosition = Math.min(position, player.item.duration_ms);
 
     return `Seeked to \`${parseMS(realPosition)}\`.`;
   }


### PR DESCRIPTION
Looks cleaner 🌮 

Also add `kip` prefix to `next` so you can do `s;kip`